### PR TITLE
Travis tests do not include recent versions of libclang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,18 @@ otp_release:
   - 17.0
 env:
   - CPATH=/usr/lib/llvm-3.4/include LIBRARY_PATH=/usr/lib/llvm-3.4/lib LD_LIBRARY_PATH=/usr/lib/llvm-3.4/lib
+  # - CPATH=/usr/lib/llvm-3.5/include LIBRARY_PATH=/usr/lib/llvm-3.4/lib LD_LIBRARY_PATH=/usr/lib/llvm-3.5/lib
+  - CPATH=/usr/lib/llvm-3.6/include LIBRARY_PATH=/usr/lib/llvm-3.4/lib LD_LIBRARY_PATH=/usr/lib/llvm-3.6/lib
+  - CPATH=/usr/lib/llvm-3.7/include LIBRARY_PATH=/usr/lib/llvm-3.4/lib LD_LIBRARY_PATH=/usr/lib/llvm-3.7/lib
 before_install:
-  - sudo add-apt-repository -y ppa:h-rayflood/llvm
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-add-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main'
+  - sudo apt-add-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main'
+  - sudo apt-add-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main'
+  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install libclang1-3.4 libclang-3.4-dev
+  # - sudo apt-get install libclang1-3.5 libclang-3.5-dev
+  - sudo apt-get install libclang1-3.6 libclang-3.6-dev
+  - sudo apt-get install libclang1-3.7 libclang-3.7-dev
 script: "make all"
-


### PR DESCRIPTION
The Travis tests only use libclang in the version 3.4 although versions up to 3.7 are available.

We should run tests for all recent libclang versions: 3.4, 3.5, 3.6, and 3.7