### PR TITLE
Implementation of enums

### DIFF
--- a/src/nifty.erl
+++ b/src/nifty.erl
@@ -351,7 +351,7 @@ size_of(Type) ->
     end.
 
 %% @doc Returns the integer value associated with an enum alias
--spec enum_value(nonempty_string(), nonempty_string() | atom()) -> integer() | undef.
+-spec enum_value(atom(), nonempty_string() | atom()) -> integer() | undef.
 enum_value(Module, Value) when is_atom(Value) ->
     enum_value(Module, atom_to_list(Value));
 enum_value(Module, Value) ->

--- a/src/nifty.erl
+++ b/src/nifty.erl
@@ -1,5 +1,5 @@
 %%% -------------------------------------------------------------------
-%%% Copyright (c) 2014, Andreas Löscher <andreas.loscher@it.uu.se> and
+%%% Copyright (c) 2015, Andreas Löscher <andreas.loscher@it.uu.se> and
 %%%                     Konstantinos Sagonas <kostis@it.uu.se>
 %%% All rights reserved.
 %%%
@@ -20,6 +20,8 @@
 	 pointer/1,
 	 pointer_of/2,
 	 pointer_of/1,
+	 %% enums
+	 enum_value/2,
 	 %% types
 	 as_type/2,
 	 size_of/1,
@@ -59,7 +61,7 @@ load_dependencies() ->
     ok = load_dependency(rebar),
     ok = load_dependency(erlydtl).
 
-load_dependency(Module) ->		    
+load_dependency(Module) ->
     case code:ensure_loaded(Module) of
 	{error, nofile} ->
 	    %% module not found
@@ -72,11 +74,11 @@ load_dependency(Module) ->
 	    end;
 	{module, Module} ->
 	    ok
-    end.    
+    end.
 
-%% @doc Generates a NIF module out of a C header file and compiles it, 
-%% generating wrapper functions for all functions present in the header file. 
-%% <code>InterfaceFile</code> specifies the header file. <code>Module</code> specifies 
+%% @doc Generates a NIF module out of a C header file and compiles it,
+%% generating wrapper functions for all functions present in the header file.
+%% <code>InterfaceFile</code> specifies the header file. <code>Module</code> specifies
 %% the module name of the translated NIF. <code>Options</code> specifies the compile
 %% options. These options are equivalent to rebar's config options.
 -spec compile(string(), module(), options()) -> 'ok' | {'error', reason()} | {'warning' , {'not_complete' , [nonempty_string()]}}.
@@ -138,7 +140,7 @@ get_derefed_type(Type, Module) ->
 	    {_, TypeDef} = dict:fetch(ResType, Types),
 	    [H|_] = TypeDef,
 	    case (H=:="*") orelse (string:str(H, "[")>0) of
-		true -> 
+		true ->
 		    [_|Token] = lists:reverse(string:tokens(ResType, " ")),
 		    NType = string:join(lists:reverse(Token), " "),
 		    ResNType = nifty_types:resolve_type(NType, Types),
@@ -146,7 +148,7 @@ get_derefed_type(Type, Module) ->
 			true ->
 			    {_, DTypeDef} = dict:fetch(ResNType, Types),
 			    [DH|_] = DTypeDef,
-			    case DH of 
+			    case DH of
 				{_, _} -> {final, ResNType};
 				_ -> case (DH=:="*") orelse (string:str(DH, "[")>0) of
 					 true -> {pointer, ResNType};
@@ -194,7 +196,7 @@ dereference(Pointer) ->
 	undef ->
 	    {error, undef}
     end.
-    %% end.
+%% end.
 
 %% build_builtin_type(DType, Address) ->
 %%     case DType of
@@ -206,12 +208,12 @@ dereference(Pointer) ->
 build_type(Module, Type, Address) ->
     Types = Module:get_types(),
     case dict:is_key(Type, Types) of
-	true -> 
+	true ->
 	    RType = nifty_types:resolve_type(Type, Types),
 	    {Kind, Def} =  dict:fetch(RType, Types),
 	    case Kind of
 		userdef ->
-		    case Def of 
+		    case Def of
 			[{struct, Name}] ->
 			    Module:erlptr_to_record({Address, Name});
 			_ ->
@@ -253,7 +255,7 @@ int_deref(Addr, Size, Sign) ->
     case Sign of
 	"signed" ->
 	    case I > (trunc(math:pow(2, (Size*8)-1))-1) of
-		true -> 
+		true ->
 		    I - trunc(math:pow(2,(Size*8)));
 		false ->
 		    I
@@ -281,10 +283,10 @@ float_deref(_) ->
 float_ref(_) ->
     erlang:nif_error(nif_library_not_loaded).
 
-double_deref(_) ->    
+double_deref(_) ->
     erlang:nif_error(nif_library_not_loaded).
 
-double_ref(_) ->    
+double_ref(_) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Converts an erlang string into a 0 terminated C string and returns a nifty pointer to it
@@ -298,7 +300,7 @@ cstr_to_list(_) ->
 
 %% @doc size of a base type, no error handling
 -spec size_of(nonempty_string()) -> integer() | undef.
-size_of(Type) -> 
+size_of(Type) ->
     Types = get_types(),
     case dict:is_key(Type, Types) of
 	true ->
@@ -331,13 +333,13 @@ size_of(Type) ->
 	false ->
 	    %% full referenced
 	    case string:tokens(Type, ".") of
-		["nifty", TypeName] -> 
+		["nifty", TypeName] ->
 		    %% builtin
 		    size_of(TypeName);
 		[ModuleName, TypeName] ->
 		    Mod = list_to_atom(ModuleName),
-		    case {module, Mod}=:=code:ensure_loaded(Mod) andalso 
-			proplists:is_defined(get_types, Mod:module_info(exports)) of
+		    case {module, Mod}=:=code:ensure_loaded(Mod) andalso
+			proplists:is_defined(size_of, Mod:module_info(exports)) of
 			true ->
 			    Mod:size_of(TypeName);
 			false ->
@@ -347,7 +349,24 @@ size_of(Type) ->
 		    undef
 	    end
     end.
-    
+
+%% @doc Returns the integer value associated with an enum alias
+-spec enum_value(nonempty_string(), nonempty_string() | atom()) -> integer() | undef.
+enum_value(Module, Value) when is_atom(Value) ->
+    enum_value(Module, atom_to_list(Value));
+enum_value(Module, Value) ->
+    case {module, Module}=:=code:ensure_loaded(Module) andalso
+	proplists:is_defined(get_enum_aliases, Module:module_info(exports)) of
+	true ->
+	    case proplists:lookup(Value, Module:get_enum_aliases()) of
+		{Value, IntValue} -> IntValue;
+		_ -> undef
+	    end;
+	false ->
+	    undef
+    end.
+
+
 %% @doc Returns a pointer to a memory area that is the size of a pointer
 -spec pointer() -> ptr().
 pointer() ->
@@ -465,11 +484,11 @@ raw_deref(_) ->
 -spec mem_write(ptr(), binary() | list()) -> ptr().
 mem_write({Addr, _} = Ptr, Data) ->
     {Addr, _} = case is_binary(Data) of
-	true ->
-	    mem_write_binary(Data, Ptr);
-	false ->
-	    mem_write_list(Data, Ptr)
-	end,
+		    true ->
+			mem_write_binary(Data, Ptr);
+		    false ->
+			mem_write_list(Data, Ptr)
+		end,
     Ptr.
 
 %% @doc Writes the <code>Data</code> to memory and returns a nifty pointer to it; the list elements are interpreted as byte values
@@ -518,7 +537,7 @@ as_type({Address, _} = Ptr, Type) ->
     BaseType = case string:tokens(Type, "*") of
 		   [T] ->
 		       string:strip(T);
-		   _ -> 
+		   _ ->
 		       []
 	       end,
     Types = get_types(),
@@ -532,7 +551,7 @@ as_type({Address, _} = Ptr, Type) ->
 		    as_type(Ptr, TypeName);
 		[ModuleName, TypeName] ->
 		    Mod = list_to_atom(ModuleName),
-		    case {module, Mod}=:=code:ensure_loaded(Mod) andalso 
+		    case {module, Mod}=:=code:ensure_loaded(Mod) andalso
 			proplists:is_defined(get_types, Mod:module_info(exports)) of
 			true ->
 			    %% resolve and build but we are looking for the basetype
@@ -542,7 +561,7 @@ as_type({Address, _} = Ptr, Type) ->
 			    RBType = string:strip(RBUType),
 			    case nifty_types:resolve_type(RBType, Mod:get_types()) of
 				undef ->
-				    case nifty_types:resolve_type(RBType++" *", Mod:get_types()) of 
+				    case nifty_types:resolve_type(RBType++" *", Mod:get_types()) of
 					undef ->
 					    %% unknown type
 					    undef;

--- a/src/nifty_filters.erl
+++ b/src/nifty_filters.erl
@@ -33,7 +33,8 @@
 	 discard_restrict/1,
 	 loopcounter/2,
 
-	 config_schedule_dirty/1]).
+	 config_schedule_dirty/1,
+	 enum_aliases/1]).
 
 -spec norm_type(string()) -> string().
 norm_type(Type) ->
@@ -138,7 +139,7 @@ is_output(Arg) ->
     (getNth(Arg, 4) =:= output) orelse (getNth(Arg, 4) =:= inoutput).
 
 -spec is_array(string()) -> boolean().
-is_array(Arg) -> 
+is_array(Arg) ->
     (is_list(Arg) andalso (string:str(Arg, "[") =:= 1 andalso length(Arg) > 2)).
 
 -spec array_type(string()) -> string().
@@ -172,7 +173,7 @@ config_schedule_dirty(Options) ->
     case proplists:get_value(nifty, Options) of
 	undefined ->
 	    false;
-	NiftyOptions -> 
+	NiftyOptions ->
 	    case proplists:get_value(schedule_dirty, NiftyOptions) of
 		undefined ->
 		    false;
@@ -181,4 +182,19 @@ config_schedule_dirty(Options) ->
 		_ ->
 		    true
 	    end
+    end.
+
+-spec enum_aliases(dict:dict()) -> nonempty_string().
+enum_aliases(Constructors) ->
+    enum_aliases(dict:fetch_keys(Constructors), Constructors, []).
+
+enum_aliases([], _, Acc) ->
+    io_lib:format("~p", [Acc]);
+enum_aliases([H|T], Constructors, Acc) ->
+    case H of
+	{enum, _} ->
+	    Aliases = dict:fetch(H, Constructors),
+	    enum_aliases(T, Constructors, Acc ++ Aliases);
+	_ ->
+	    enum_aliases(T, Constructors, Acc)
     end.

--- a/templates/emodule.tpl
+++ b/templates/emodule.tpl
@@ -2,6 +2,7 @@
 -export([{% with fn=symbols|fetch_keys %}{% for name in fn %}
 	'{{name}}'/{{ symbols|fetch:name|length|add:-1 }},{% endfor %}{% endwith %}
 	get_types/0,
+	get_enum_aliases/0,
 	erlptr_to_record/1,
 	record_to_erlptr/1,
 	new/1,
@@ -9,6 +10,8 @@
 	]).
 
 -define(TYPES, {{types}}).
+
+-define(ENUM_ALIASES, {{constructors|enum_aliases}}).
 
 -on_load(init/0).
 
@@ -43,6 +46,9 @@ record_to_erlptr(_) ->
 
 -spec get_types() -> dict:dict().
 get_types() -> ?TYPES.
+
+-spec get_enum_aliases() -> proplist:proplist().
+get_enum_aliases() -> ?ENUM_ALIASES.
 
 -spec new(typename()) -> term().
 new(_) ->

--- a/templates/lib/int_type.tpl
+++ b/templates/lib/int_type.tpl
@@ -28,7 +28,7 @@
 {% endif %}
 
 {% if phase=="to_c" %}
-	err = 
+	err =
 	{% if typedef|getNth:2=="unsigned" and (typedef|getNth:3=="short" or typedef|getNth:1=="char") %}enif_get_uint{% endif %}
 	{% if typedef|getNth:2=="signed" and (typedef|getNth:3=="short" or typedef|getNth:1=="char") %}enif_get_int{% endif %}
 	{% if typedef|getNth:2=="unsigned" and (typedef|getNth:3=="none" and typedef|getNth:1=="int") %}enif_get_uint{% endif %}
@@ -37,7 +37,12 @@
 	{% if typedef|getNth:2=="signed" and typedef|getNth:3=="long" %}enif_get_long{% endif %}
 	{% if typedef|getNth:2=="unsigned" and typedef|getNth:3=="longlong" %}enif_get_uint64{% endif %}
 	{% if typedef|getNth:2=="signed" and typedef|getNth:3=="longlong" %}enif_get_int64{% endif %}
-	(env, {{erlarg}}, &{% if typedef|getNth:3=="short" or typedef|getNth:1=="char" %}helper{{N}}{% else %}{{carg}}{% endif %});
+	(env, {{erlarg}},
+	{% if typedef|getNth:3=="short" or typedef|getNth:1=="char" %}&helper{{N}}{% else %}
+	{% if typedef|getNth:2=="unsigned" and typedef|getNth:3=="longlong" %}(unsigned long int*){%endif%}
+	{% if typedef|getNth:2=="signed" and typedef|getNth:3=="longlong" %}(long int*){%endif%}
+	(&{{carg}})
+	{% endif %});
 	{% if typedef|getNth:3=="short" or typedef|getNth:1=="char" %}
 	{{carg}}=({{type}})helper{{N}};
 	{% endif %}
@@ -52,7 +57,7 @@
 {% endif %}
 
 {% if phase=="to_erl"%}
-	{{erlarg}} = 
+	{{erlarg}} =
 	{% if typedef|getNth:2=="unsigned" and (typedef|getNth:3=="short" or typedef|getNth:1=="char") %}enif_make_uint{% endif %}
 	{% if typedef|getNth:2=="signed" and (typedef|getNth:3=="short" or typedef|getNth:1=="char") %}enif_make_int{% endif %}
 	{% if typedef|getNth:2=="unsigned" and (typedef|getNth:3=="none" and typedef|getNth:1=="int") %}enif_make_uint{% endif %}

--- a/test/cfiles/enums.h
+++ b/test/cfiles/enums.h
@@ -1,0 +1,24 @@
+#ifndef NIFTY_ENUMS_TEST
+#define NIFTY_ENUMS_TEST
+
+enum enum0 {
+  THE_VALUE
+};
+
+typedef enum enum1 {
+  VALUE1,
+  VALUE2,
+  VALUE3
+} enum1_t;
+
+ enum enum2 {
+  VALUE4 = 4,
+  VALUE5,
+  VALUE6 = 100
+};
+
+enum1_t f1(enum enum0 par1, enum enum2 par2) {
+        return VALUE2;
+}
+
+#endif /* NIFTY_ENUMS_TEST */

--- a/test/nifty_test.erl
+++ b/test/nifty_test.erl
@@ -1,3 +1,12 @@
+%%% -------------------------------------------------------------------
+%%% Copyright (c) 2015, Andreas Löscher <andreas.loscher@it.uu.se> and
+%%%                     Konstantinos Sagonas <kostis@it.uu.se>
+%%% All rights reserved.
+%%%
+%%% This file is distributed under the Simplified BSD License.
+%%% Details can be found in the LICENSE file.
+%%% -------------------------------------------------------------------
+
 -module(nifty_test).
 -compile(export_all).
 
@@ -10,9 +19,9 @@
 
 -spec compile_builtin() -> ok.
 compile_builtin() ->
-    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/builtin_types.h", 
-					 nt_builtin, 
-					 ?OPTS("../test/cfiles/builtin_types.c"))).
+    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/builtin_types.h",
+					     nt_builtin,
+					     ?OPTS("../test/cfiles/builtin_types.c"))).
 
 -spec call_functions_builtin() -> term().
 call_functions_builtin() ->
@@ -28,10 +37,10 @@ call_functions_builtin() ->
      ?_assertEqual(1.0, nt_builtin:f10(1.0)),
      ?_assertEqual({0, "nt_builtin.void *"}, nt_builtin:f11({0, "void *"})),
      ?_assertEqual(ok, fun () ->
-				 P = nifty:mem_alloc(10),
-				 {_, _} = nt_builtin:f12(P),
-				 nifty:free(P)
-			 end())].
+			       P = nifty:mem_alloc(10),
+			       {_, _} = nt_builtin:f12(P),
+			       nifty:free(P)
+		       end())].
 
 -spec builtin_test_() -> term().
 builtin_test_() ->
@@ -66,8 +75,8 @@ builtin_test_() ->
 
 -spec compile_arguments() -> term().
 compile_arguments() ->
-    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/arguments.h", 
-					     nt_arguments, 
+    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/arguments.h",
+					     nt_arguments,
 					     ?OPTS("../test/cfiles/arguments.c"))).
 
 -spec call_functions_arguments() -> term().
@@ -102,11 +111,11 @@ structs_test_() ->
 
 -spec compile_proxy() -> term().
 compile_proxy() ->
-    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/proxy_header.h", 
-				nt_proxy, 
-				nifty_utils:add_sources(
-				  ["../test/cfiles/proxy_header.c"],
-				  nifty_utils:add_cflags("-I../test/cfiles", [])))).
+    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/proxy_header.h",
+					     nt_proxy,
+					     nifty_utils:add_sources(
+					       ["../test/cfiles/proxy_header.c"],
+					       nifty_utils:add_cflags("-I../test/cfiles", [])))).
 
 -spec call_functions_proxy() -> term().
 call_functions_proxy() ->
@@ -121,21 +130,21 @@ proxy_test_()->
 
 -spec fptr_test_() -> term().
 fptr_test_() ->
-    {timeout, 60, 
+    {timeout, 60,
      ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/fptr.h", nt_fptr, []))}.
 
 -spec compile_array() -> term().
 compile_array() ->
     ?_assertEqual(ok, nifty_compiler:compile(
-			"../test/cfiles/array.h", nt_array, 
+			"../test/cfiles/array.h", nt_array,
 			nifty_utils:add_sources(["../test/cfiles/array.c"], []))).
 
 -spec call_functions_array() -> ok.
 call_functions_array() ->
     [?_assertEqual(10, nt_array:sumarray(nifty:mem_write([1,0,0,0,1,0,0,0,1,0,0,0,
-							 1,0,0,0,1,0,0,0,1,0,0,0,
-							 1,0,0,0,1,0,0,0,1,0,0,0,
-							 1,0,0,0]))),
+							  1,0,0,0,1,0,0,0,1,0,0,0,
+							  1,0,0,0,1,0,0,0,1,0,0,0,
+							  1,0,0,0]))),
      ?_assertEqual(20, fun () ->
 			       B = [1,1,1,1,1,1,1,1,1,1],
 			       Rec = {array_st, nifty:mem_write(B), 0, nifty:mem_write(B)},
@@ -150,8 +159,8 @@ array_test_() ->
 
 -spec compile_tut2() -> term().
 compile_tut2() ->
-    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/answer.h", 
-					     nt_tut2, 
+    ?_assertEqual(ok, nifty_compiler:compile("../test/cfiles/answer.h",
+					     nt_tut2,
 					     nifty_utils:add_sources(
 					       ["../test/cfiles/answer.c"],
 					       nifty_utils:add_cflags(
@@ -165,3 +174,19 @@ call_tut2() ->
 tut2_test_()->
     {timeout, 60, [compile_tut2(),
 		   call_tut2()]}.
+
+-spec enum_test_() -> term().
+enum_test_() ->
+    {timeout, 60,
+     [compile_enum(),
+      call_enum(),
+      check_enum()]}.
+
+compile_enum() ->
+    ?_assertEqual(ok, nifty:compile("../test/cfiles/enums.h", nt_enums, [])).
+
+call_enum() ->
+    ?_assertEqual(1, nt_enums:f1(1,2)).
+
+check_enum() ->
+    ?_assertEqual(100, nifty:enum_value(nt_enums, "VALUE6")).


### PR DESCRIPTION
Usage:
+ enums default to long long
+ nifty:enum_value(module, ALIAS) returns the integer value associated with the alias

So if we compile something like:

    enum foo {
      FOO_ONE = 42
    };

into module foo then we can do 

    > nifty:enum_value(foo, "FOO_ONE").
    42

