### PR TITLE
Purge loaded module

### DIFF
--- a/src/nifty.erl
+++ b/src/nifty.erl
@@ -139,6 +139,7 @@ compile(InterfaceFile, Module, Options) ->
         ok ->
           ModulePath = filename:absname(filename:join([ModuleName, "ebin"])),
           true = code:add_patha(ModulePath),
+          purge_code(Module),
           case Lost of
             [] -> ok;
             _ -> {warning, {not_complete, Lost}}
@@ -146,6 +147,21 @@ compile(InterfaceFile, Module, Options) ->
         fail ->
           {error, compile}
       end
+  end.
+
+purge_code(Module) ->
+  case code:is_loaded(Module) of
+    false ->
+      false;
+    {file, _Loaded} ->
+      case check_old_code(Module) of
+        false ->
+          code:delete(Module);
+        true ->
+          nop
+      end,
+      code:purge(Module),
+      true
   end.
 
 -type renderout() :: {iolist(), iolist(), iolist(), iolist(), iolist(), iolist()}.


### PR DESCRIPTION
This will purge already loaded code and will make new code available automatically.

I was trying to work through this Quickcheck video https://vimeo.com/104007760 and
immediately found that Nifty doesn't reload the module itself  after recompile. This commit
fixes this. Please notice if the code doesn't load the module.

