### PR TITLE
Rename auto-generated functions to avoid name clashes

### DIFF
--- a/templates/cmodule.tpl
+++ b/templates/cmodule.tpl
@@ -66,8 +66,8 @@ static ErlNifFunc nif_functions[] = {
 	{"record_to_erlptr", 1, record_to_erlptr},
 	{"erlptr_to_urecord", 1, erlptr_to_urecord},
 	{"urecord_to_erlptr", 1, urecord_to_erlptr},
-	{"new", 1, new_type_object},
-	{"size_of", 1, size_of}
+	{"__nifty__new", 1, new_type_object},
+	{"__nifty__size_of", 1, size_of}
 	};
 
 int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info)

--- a/templates/emodule.tpl
+++ b/templates/emodule.tpl
@@ -2,15 +2,14 @@
 
 -export([{% with fn=symbols|fetch_keys %}{% for name in fn %}
 	'{{name}}'/{{ symbols|fetch:name|length|add:-1 }},{% endfor %}{% endwith %}
-	get_types/0,
-	get_enum_aliases/0,
 	erlptr_to_record/1,
 	record_to_erlptr/1,
 	erlptr_to_urecord/1,
 	urecord_to_erlptr/1,
-	new/1,
-	size_of/1
-	]).
+	'__nifty__get_types'/0,
+	'__nifty__get_enum_aliases'/0,
+	'__nifty__new'/1,
+	'__nifty__size_of'/1]).
 
 -define(TYPES, {{types}}).
 
@@ -18,9 +17,9 @@
 
 -on_load(init/0).
 
--type addr() :: integer().
+-type addr()     :: integer().
 -type typename() :: string().
--type ptr() :: {addr(), typename()}.
+-type ptr()      :: {addr(), typename()}.
 
 init() ->
     PrivDir = case code:priv_dir(?MODULE) of
@@ -55,16 +54,18 @@ erlptr_to_urecord(_) ->
 urecord_to_erlptr(_) ->
     erlang:nif_error(nif_library_not_loaded).
 
--spec get_types() -> dict:dict().
-get_types() -> ?TYPES.
+-spec '__nifty__get_types'() -> nifty_clangparse:type_table().
+'__nifty__get_types'() ->
+    ?TYPES.
 
--spec get_enum_aliases() -> proplist:proplist().
-get_enum_aliases() -> ?ENUM_ALIASES.
+-spec '__nifty__get_enum_aliases'() -> proplist:proplist().
+'__nifty__get_enum_aliases'() ->
+    ?ENUM_ALIASES.
 
--spec new(typename()) -> term().
-new(_) ->
+-spec '__nifty__new'(typename()) -> term().
+'__nifty__new'(_) ->
     erlang:nif_error(nif_library_not_loaded).
 
--spec size_of(typename()) -> integer() | undef.
-size_of(_) ->
+-spec '__nifty__size_of'(typename()) -> integer() | undef.
+'__nifty__size_of'(_) ->
     erlang:nif_error(nif_library_not_loaded).

--- a/templates/save_emodule.tpl
+++ b/templates/save_emodule.tpl
@@ -5,11 +5,10 @@
 	start/0,
 	stop/0,
 	restart/0,
-	get_types/0,
 	erlptr_to_record/1,
 	record_to_erlptr/1,
-	new/1
-	]).
+	'__nifty__get_types'/0,
+	'__nifty__new'/1]).
 
 -type addr() :: integer().
 -type typename() :: string().
@@ -42,10 +41,10 @@ erlptr_to_record(Ptr) ->
 record_to_erlptr(Rec) ->
     nifty_remotecall:call_remote({{module}}, record_to_erlptr, [Rec]).
 
--spec get_types() -> dict:dict() | error().
-get_types() ->
-    nifty_remotecall:call_remote({{module}}, get_types, []).
+-spec '__nifty__get_types'() -> nifty_clangparse:type_table() | error().
+'__nifty__get_types'() ->
+    nifty_remotecall:call_remote({{module}}, '__nifty__get_types', []).
 
--spec new(typename()) -> term().
-new(Type) ->
-    nifty_remotecall:call_remote({{module}}, new, [Type]).
+-spec '__nifty__new'(typename()) -> term().
+'__nifty__new'(Type) ->
+    nifty_remotecall:call_remote({{module}}, '__nifty__new', [Type]).

--- a/test/nifty_test.erl
+++ b/test/nifty_test.erl
@@ -98,10 +98,10 @@ compile_structs() ->
 
 -spec  call_functions_structs() -> ok.
 call_functions_structs() ->
-  [?_assertMatch({_,_,_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:new("struct s1")))),
-   ?_assertMatch({_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:new("struct s2")))),
-   ?_assertMatch({_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:new("struct s3")))),
-   ?_assertMatch({_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:new("struct s4")))),
+  [?_assertMatch({_,_,_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:'__nifty__new'("struct s1")))),
+   ?_assertMatch({_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:'__nifty__new'("struct s2")))),
+   ?_assertMatch({_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:'__nifty__new'("struct s3")))),
+   ?_assertMatch({_,_,_}, nifty:dereference(nt_structs:record_to_erlptr(nt_structs:'__nifty__new'("struct s4")))),
    ?_assertEqual({'struct s4', 0.5, 10}, nifty:dereference(nifty:pointer_of({'struct s4', 0.5, 10}, "nt_structs.struct s4")))].
 
 -spec structs_test_() -> term().


### PR DESCRIPTION
This fixes issue #58 that reported a clash in the use of 'new' as a
function name in a C file.  While at it, did some code cleanups.